### PR TITLE
Handle negative decimals in Persian number conversion

### DIFF
--- a/PersianTools/PersianTools.Lib/NumberToPersianString.cs
+++ b/PersianTools/PersianTools.Lib/NumberToPersianString.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Globalization;
 using SCICT.NLP.Utility.Parsers;
 
 namespace SCICT.NLP.Utility
@@ -41,20 +42,24 @@ namespace SCICT.NLP.Utility
             str = "";
             try
             {
-                string strValue = d.ToString("F20");
+                bool isNegative = d < 0;
+                if (isNegative)
+                    d = -d;
+
+                string strValue = d.ToString("F20", CultureInfo.InvariantCulture);
                 int dotIndex = strValue.IndexOf('.');
                 if (dotIndex > 0)
                 {
                     string preDot = strValue.Substring(0, dotIndex);
                     string postDot = MathUtils.RemoveTrailingZeros(strValue.Substring(dotIndex + 1));
 
-                    int numPreDot, numPostDot;
-                    if (!Int32.TryParse(preDot, out numPreDot))
+                    long numPreDot, numPostDot;
+                    if (!Int64.TryParse(preDot, NumberStyles.None, CultureInfo.InvariantCulture, out numPreDot))
                         return false;
 
                     if (postDot.Length > 0)
                     {
-                        if (!Int32.TryParse(postDot, out numPostDot))
+                        if (!Int64.TryParse(postDot, NumberStyles.None, CultureInfo.InvariantCulture, out numPostDot))
                             return false;
 
                         if (numPreDot != 0)
@@ -68,11 +73,18 @@ namespace SCICT.NLP.Utility
                     {
                         str += ToString(numPreDot);
                     }
+
+                    if (isNegative)
+                        str = "منفی " + str;
+
                     return true;
                 }
                 else
                 {
-                    return TryConvertNumberToPersianString(Convert.ToInt64(d), out str);
+                    bool res = TryConvertNumberToPersianString(Convert.ToInt64(d), out str);
+                    if (res && isNegative)
+                        str = "منفی " + str;
+                    return res;
                 }
             }
             catch
@@ -108,7 +120,7 @@ namespace SCICT.NLP.Utility
 
             if (x < 0L)
             {
-                result = "منهای ";
+                result = "منفی ";
                 x = -x;
             }
 

--- a/VirastyarWordAddin/VirastyarWordAddin/VirastyarWordAddin.csproj
+++ b/VirastyarWordAddin/VirastyarWordAddin/VirastyarWordAddin.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="3.5" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project ToolsVersion="16.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!--
     This section defines project-level properties.
 
@@ -25,7 +25,7 @@
     <NoStandardLibraries>false</NoStandardLibraries>
     <RootNamespace>VirastyarWordAddin</RootNamespace>
     <AssemblyName>VirastyarWordAddin</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\Product_StrongKey\Virastyar.snk</AssemblyOriginatorKeyFile>
     <PublishUrl>publish\</PublishUrl>
@@ -543,20 +543,15 @@
   <!-- Include the build rules for a C# project. -->
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- Include additional build rules for an Office application add-in. -->
-  <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v9.0\OfficeTools\Microsoft.VisualStudio.Tools.Office.Office2003.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v16.0\OfficeTools\Microsoft.VisualStudio.Tools.Office.targets" />
   <!-- This section defines VSTO properties that describe the host-changeable project properties. -->
   <ProjectExtensions>
     <VisualStudio>
       <FlavorProperties GUID="{BAA0C2D2-18E2-41B9-852F-F413020CAA33}">
-        <ProjectProperties HostName="Word" HostPackage="{D53BAEDE-5B63-42BE-8267-3DED11EDC582}" OfficeVersion="11.0" VstxVersion="3.0" ApplicationType="Word" Language="cs" TemplatesPath="" DebugInfoExeName="#Software\Microsoft\Office\11.0\Word\InstallRoot\Path#winword.exe" DebugInfoCommandLine="/w" />
+        <ProjectProperties HostName="Word" HostPackage="{D53BAEDE-5B63-42BE-8267-3DED11EDC582}" OfficeVersion="16.0" VstxVersion="3.0" ApplicationType="Word" Language="cs" TemplatesPath="" DebugInfoExeName="#Software\Microsoft\Office\16.0\Word\InstallRoot\Path#winword.exe" DebugInfoCommandLine="/w" />
         <Host Name="Word" GeneratedCodeNamespace="VirastyarWordAddin" IconIndex="0">
           <HostItem Name="ThisAddIn" Code="ThisAddIn.cs" CanonicalName="AddIn" CanActivate="false" IconIndex="1" Blueprint="ThisAddIn.Designer.xml" GeneratedCode="ThisAddIn.Designer.cs" />
         </Host>
-        <ProjectClient>
-          <VSTO_CompatibleProducts ErrorProduct="This project requires Microsoft Office Word 2003 and the registered primary interop assemblies, but these are not installed." ErrorPIA="This project references the primary interop assembly for Microsoft Office Word 2003, but this primary interop assembly is not installed.">
-            <Product Code="{XXXXXXXX-6000-11D3-8CFE-0150048383C9}" Feature="WORDFiles" PIAFeature="Word_PIA" />
-          </VSTO_CompatibleProducts>
-        </ProjectClient>
       </FlavorProperties>
     </VisualStudio>
   </ProjectExtensions>


### PR DESCRIPTION
## Summary
- support negative double values in Persian number-to-string conversion
- allow larger integer parts by parsing with Int64 instead of Int32
- target .NET Framework 4.8 and Office 16 for Word add-in to support Word 2019+
- use culture-invariant formatting and the proper "منفی" prefix when generating negative numbers

## Testing
- `msbuild VirastyarWordAddin/VirastyarWordAddin/VirastyarWordAddin.csproj /p:Configuration=Release` *(fails: command not found)*
- `dotnet build VirastyarWordAddin/VirastyarWordAddin/VirastyarWordAddin.csproj -c Release` *(fails: command not found)*
- `mcs -target:library -out:/tmp/test/NumberLib.dll PersianTools/PersianTools.Lib/NumberToPersianString.cs PersianTools/PersianTools.Lib/MathUtils.cs PersianTools/PersianTools.Lib/PersianParsers/PersianLiteral2Num.cs`
- `mcs -r:/tmp/test/NumberLib.dll -out:/tmp/test/test.exe /tmp/test/test.cs`
- `mono /tmp/test/test.exe`


------
https://chatgpt.com/codex/tasks/task_e_68bf4a4793348329b9126f3a9d338838